### PR TITLE
[extractHip] handle raw RGBA images

### DIFF
--- a/extractHip.py
+++ b/extractHip.py
@@ -11,17 +11,26 @@ for filename in glob.glob("bbcf2/char_ct_img.pac.extracted/*.hip"):
     f = open(filename,"rb")
     if f.read(4) != "HIP\x00":
         continue
-    DATA = struct.unpack("<3I4I4I4I",f.read(0x3C))
+    DATA = struct.unpack("<3I4I",f.read(0x1C))
     #print hex(DATA[6]&0xFFFF)
     #DATA2 = TOTAL_SIZE,PALLETE SIZE
     tmp = f.tell()
     f.seek(0,2)
     end = f.tell()
     f.seek(tmp)
-    if DATA[2] == 0:
-        print "WHAT IS THIS",filename
 
+    # Raw RGBA image
+    if DATA[2] == 0:
+        RAW_DATA = StringIO()
+        while f.tell() < end:
+            color = struct.unpack("4B",f.read(4))[::-1]
+            counter = ord(f.read(1))
+            RAW_DATA.write(struct.pack("4B",*color)*counter)
+        img = Image.frombytes("RGBA",(DATA[3],DATA[4]),RAW_DATA.getvalue(),"raw","ARGB")
+
+    # Palette image
     else:
+        DATA += struct.unpack("<4I4I",f.read(0x20))
 
         PALLETE = []
         for i in range(0, 256):


### PR DESCRIPTION
When the color number header field is 0 then the image is not a palette image, it is a raw RGBA image. The formatting of the HIP file is the same but instead of the data being (palette_index, pixel_count) tuples, it is (B, G, R, A, pixel_count) tuples.

Note that for raw images that the header is not the same size as for palette images. The header for a palette image is 32 bytes longer, and this extra data is where the width and height for palette images comes from, despite the fact that there are width and height fields in the first 28 bytes of the header that both image types share.